### PR TITLE
Initialize Resources on Enable

### DIFF
--- a/Editor/Resources.cs
+++ b/Editor/Resources.cs
@@ -18,7 +18,7 @@ namespace GitMerge
             }
         }
 
-        static Resources()
+        public void OnEnable()
         {
             styles = UnityEngine.Resources.Load<Resources>("GitMergeStyles");
         }


### PR DESCRIPTION
Instead of initializing on the static ScriptableObject constructor, that is deprecated.
Unity 5.6+ doesn't seem to allow the static constructor on ScriptableObjects.