### PR TITLE
Add a command bar to help merge process

### DIFF
--- a/Editor/GameObjectMergeActions.cs
+++ b/Editor/GameObjectMergeActions.cs
@@ -22,7 +22,7 @@ namespace GitMerge
         /// </summary>
         public GameObject theirs { private set; get; }
 
-        private string name;
+        public string name { private set; get; }
         public bool merged { private set; get; }
         public bool hasActions
         {

--- a/Editor/GitMergeWindow.cs
+++ b/Editor/GitMergeWindow.cs
@@ -269,7 +269,7 @@ namespace GitMerge
         private bool DisplayMergeActions()
         {
             scrollPosition = GUILayout.BeginScrollView(scrollPosition, false, true);
-            GUILayout.BeginVertical(GUILayout.MinWidth(480));
+            GUILayout.BeginVertical(GUILayout.ExpandWidth(true));
 
             var textColor = GUI.skin.label.normal.textColor;
             GUI.skin.label.normal.textColor = Color.black;

--- a/Editor/GitMergeWindow.cs
+++ b/Editor/GitMergeWindow.cs
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
 using UnityEditor;
 using UnityEngine.SceneManagement;
+using System;
 
 namespace GitMerge
 {
@@ -21,6 +22,8 @@ namespace GitMerge
 
         //The MergeManager that has the actual merging logic
         private MergeManager manager;
+        private MergeFilter filter = new MergeFilter();
+        private MergeFilterBar filterBar = new MergeFilterBar();
 
         public bool mergeInProgress
         {
@@ -46,6 +49,7 @@ namespace GitMerge
 
         void OnEnable()
         {
+            filterBar.filter = filter;
             LoadSettings();
         }
 
@@ -97,7 +101,6 @@ namespace GitMerge
         {
             Resources.DrawLogo();
             DrawTabButtons();
-
             switch (tab)
             {
                 case 0:
@@ -217,6 +220,8 @@ namespace GitMerge
         {
             if (mergeInProgress)
             {
+                DrawCommandBar();
+
                 var done = DisplayMergeActions();
                 GUILayout.BeginHorizontal();
                 if (done && GUILayout.Button("Apply merge"))
@@ -226,6 +231,35 @@ namespace GitMerge
                 }
                 GUILayout.EndHorizontal();
             }
+        }
+
+        /// <summary>
+        /// Display extra commands to simplify merge process
+        /// </summary>
+        private void DrawCommandBar()
+        {
+            DrawQuickMergeSideSelectionCommands();
+            filterBar.Draw();
+        }
+
+        /// <summary>
+        /// Allow to select easily 'use ours' or 'use theirs' for all actions
+        /// </summary>
+        private void DrawQuickMergeSideSelectionCommands()
+        {
+            GUILayout.BeginHorizontal();
+            {
+                if (GUILayout.Button(new GUIContent("Use ours", "Use theirs for all. Do not apply merge automatically.")))
+                {
+                    manager.allMergeActions.ForEach((action) => action.UseOurs());
+                }
+                if (GUILayout.Button(new GUIContent("Use theirs", "Use theirs for all. Do not apply merge automatically.")))
+                {
+                    manager.allMergeActions.ForEach((action) => action.UseTheirs());
+                }
+                GUILayout.FlexibleSpace();
+            }
+            GUILayout.EndHorizontal();
         }
 
         /// <summary>
@@ -243,8 +277,11 @@ namespace GitMerge
             var done = true;
             foreach (var actions in manager.allMergeActions)
             {
-                actions.OnGUI();
-                done = done && actions.merged;
+                if (filter.IsPassingFilter(actions.name))
+                {
+                    actions.OnGUI();
+                    done = done && actions.merged;
+                }
             }
 
             GUI.skin.label.normal.textColor = textColor;

--- a/Editor/MergeFilter.cs
+++ b/Editor/MergeFilter.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using UnityEngine;
+
+public class MergeFilter
+{
+    public enum FilterMode
+    {
+        Inclusion,
+        Exclusion
+    }
+
+    public bool useFilter { get; set; } = false;
+    public bool isRegex { get; set; } = false;
+    public bool isCaseSensitive { get; set; } = false;
+
+    private string _expression = string.Empty;
+    public string expression
+    {
+        get => _expression;
+        set
+        {
+            if (_expression != value)
+            {
+                _expression = value;
+                regex = new Regex(_expression);
+            }
+        }
+    }
+
+    public FilterMode filterMode { get; set; } = FilterMode.Inclusion;
+
+    private Regex regex = new Regex(string.Empty);
+
+    public bool IsPassingFilter(string input)
+    {
+        if (!useFilter)
+        {
+            return true;
+        }
+
+        bool isPassingFilter = false;
+
+        if (isRegex)
+        {
+            isPassingFilter = regex.IsMatch(input);
+        }
+        else
+        {
+            if (!isCaseSensitive)
+            {
+                input = input.ToLowerInvariant();
+                isPassingFilter = input.Contains(_expression.ToLowerInvariant());
+            }
+            else
+            {
+                isPassingFilter = input.Contains(_expression);
+            }
+        }
+
+        if (filterMode == FilterMode.Exclusion)
+        {
+            isPassingFilter = !isPassingFilter;
+        }
+
+        return isPassingFilter;
+    }
+}

--- a/Editor/MergeFilter.cs.meta
+++ b/Editor/MergeFilter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: edab603871662724cb02582fea7689be
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/MergeFilterBar.cs
+++ b/Editor/MergeFilterBar.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEditor.AnimatedValues;
+using UnityEngine;
+
+public class MergeFilterBar
+{
+    public MergeFilter filter { get; set; }
+
+    private AnimBool filterAnimAlpha;
+
+    public void Draw()
+    {
+        filter.useFilter = GUILayout.Toggle(filter.useFilter, "Filter");
+        if (filter.useFilter)
+        {
+            using (new EditorGUI.IndentLevelScope())
+            {
+                filter.filterMode = (MergeFilter.FilterMode)EditorGUILayout.EnumPopup("Mode", filter.filterMode, GUILayout.ExpandWidth(false));
+                filter.isRegex = EditorGUILayout.Toggle("Regex?", filter.isRegex);
+                if (!filter.isRegex)
+                {
+                    filter.isCaseSensitive = EditorGUILayout.Toggle("Case Sensitive", filter.isCaseSensitive);
+                }
+                filter.expression = EditorGUILayout.TextField("Expression", filter.expression, GUILayout.ExpandWidth(true));
+            }
+        }
+    }
+}

--- a/Editor/MergeFilterBar.cs.meta
+++ b/Editor/MergeFilterBar.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2342757c23c8b444d9923edcc54ada06
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/ObjectDictionaries.cs
+++ b/Editor/ObjectDictionaries.cs
@@ -244,7 +244,7 @@ namespace GitMerge
         {
             foreach (var obj in theirObjects.Keys)
             {
-                if (obj.transform.parent == null)
+                if (obj != null && obj.transform.parent == null)
                 {
                     Object.DestroyImmediate(obj);
                 }


### PR DESCRIPTION
+ Add 2 buttons "Use ours" / "Use theirs" at the top to select all "ours" or all "theirs" in one row. In my use case, almost everything should be "use ours" except few ones so it was faster to use that instead of clicking each button individually
+ Add a filter bar, allowing to display only some modification (based on the action's name)
 - is filter enabled
 - is filter regex
 - is filter inclusive or exclusive
 - is case sensitive or not (if not a regex)
+ Little improvement to increase stability by not trying to delete GameObjects that are already deleted
+ Merge action now takes all the space horizontally instead of having a fixed size. Don't know why but MinWidth seems to override the Width instead of just setting a minimum