### PR TITLE
Use a page view for conflicts

### DIFF
--- a/Editor/GitMergeWindow.cs
+++ b/Editor/GitMergeWindow.cs
@@ -4,6 +4,7 @@ using UnityEngine.SceneManagement;
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using GitMerge.Utilities;
 
 namespace GitMerge
 {
@@ -278,7 +279,7 @@ namespace GitMerge
             var textColor = GUI.skin.label.normal.textColor;
             GUI.skin.label.normal.textColor = Color.black;
 
-            bool done = false;
+            bool done = true;
 
             pageView.Draw(mergeActionsFiltered.Count, (index) =>
             {
@@ -295,7 +296,7 @@ namespace GitMerge
         {
             if (filter.useFilter)
             {
-                mergeActionsFiltered = manager.allMergeActions.Where((actions) => filter.IsPassingFilter(actions.name)).ToList();
+                mergeActionsFiltered = manager.allMergeActions.Where((actions) => filter.IsPassingFilter(actions)).ToList();
             }
             else
             {

--- a/Editor/GitMergeWindow.cs
+++ b/Editor/GitMergeWindow.cs
@@ -2,6 +2,8 @@
 using UnityEditor;
 using UnityEngine.SceneManagement;
 using System;
+using System.Linq;
+using System.Collections.Generic;
 
 namespace GitMerge
 {
@@ -33,9 +35,10 @@ namespace GitMerge
             }
         }
 
+        private PageView pageView = new PageView();
         private Vector2 scrollPosition = Vector2.zero;
         private int tab = 0;
-
+        private List<GameObjectMergeActions> mergeActionsFiltered;
 
         [MenuItem("Window/GitMerge")]
         static void OpenEditor()
@@ -49,7 +52,9 @@ namespace GitMerge
 
         void OnEnable()
         {
+            pageView.NumElementsPerPage = 200;
             filterBar.filter = filter;
+            filter.OnChanged += CacheMergeActions;
             LoadSettings();
         }
 
@@ -133,6 +138,7 @@ namespace GitMerge
                 if (mm.InitializeMerge())
                 {
                     manager = mm;
+                    CacheMergeActions();
                 }
             }
 
@@ -154,6 +160,7 @@ namespace GitMerge
                     if (mm.InitializeMerge(prefab))
                     {
                         manager = mm;
+                        CacheMergeActions();
                     }
                 }
             }
@@ -268,27 +275,32 @@ namespace GitMerge
         /// <returns>True, if all MergeActions are flagged as "merged".</returns>
         private bool DisplayMergeActions()
         {
-            scrollPosition = GUILayout.BeginScrollView(scrollPosition, false, true);
-            GUILayout.BeginVertical(GUILayout.ExpandWidth(true));
-
             var textColor = GUI.skin.label.normal.textColor;
             GUI.skin.label.normal.textColor = Color.black;
 
-            var done = true;
-            foreach (var actions in manager.allMergeActions)
+            bool done = false;
+
+            pageView.Draw(mergeActionsFiltered.Count, (index) =>
             {
-                if (filter.IsPassingFilter(actions.name))
-                {
-                    actions.OnGUI();
-                    done = done && actions.merged;
-                }
-            }
+                var actions = mergeActionsFiltered[index];
+                actions.OnGUI();
+                done = done && actions.merged;
+            });
 
             GUI.skin.label.normal.textColor = textColor;
-
-            GUILayout.EndVertical();
-            GUILayout.EndScrollView();
             return done;
+        }
+
+        private void CacheMergeActions()
+        {
+            if (filter.useFilter)
+            {
+                mergeActionsFiltered = manager.allMergeActions.Where((actions) => filter.IsPassingFilter(actions.name)).ToList();
+            }
+            else
+            {
+                mergeActionsFiltered = manager.allMergeActions;
+            }
         }
     }
 }

--- a/Editor/MergeFilter.cs
+++ b/Editor/MergeFilter.cs
@@ -1,69 +1,162 @@
-﻿using System.Collections;
+﻿using GitMerge;
+using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using UnityEngine;
 
-public class MergeFilter
+namespace GitMerge
 {
-    public enum FilterMode
+    public class MergeFilter
     {
-        Inclusion,
-        Exclusion
-    }
+        public event Action OnChanged;
 
-    public bool useFilter { get; set; } = false;
-    public bool isRegex { get; set; } = false;
-    public bool isCaseSensitive { get; set; } = false;
-
-    private string _expression = string.Empty;
-    public string expression
-    {
-        get => _expression;
-        set
+        public enum FilterMode
         {
-            if (_expression != value)
+            Inclusion,
+            Exclusion
+        }
+
+        [System.Flags]
+        public enum FilterState
+        {
+            Conflict = 0x01,
+            Done = 0x02
+        }
+
+        private bool _useFilter = false;
+        public bool useFilter
+        {
+            get => _useFilter;
+            set
             {
-                _expression = value;
-                regex = new Regex(_expression);
+                if (_useFilter != value)
+                {
+                    _useFilter = value;
+                    OnChanged?.Invoke();
+                }
             }
         }
-    }
 
-    public FilterMode filterMode { get; set; } = FilterMode.Inclusion;
-
-    private Regex regex = new Regex(string.Empty);
-
-    public bool IsPassingFilter(string input)
-    {
-        if (!useFilter)
+        private bool _isRegex = false;
+        public bool isRegex
         {
-            return true;
-        }
-
-        bool isPassingFilter = false;
-
-        if (isRegex)
-        {
-            isPassingFilter = regex.IsMatch(input);
-        }
-        else
-        {
-            if (!isCaseSensitive)
+            get => _isRegex;
+            set
             {
-                input = input.ToLowerInvariant();
-                isPassingFilter = input.Contains(_expression.ToLowerInvariant());
+                if (_isRegex != value)
+                {
+                    _isRegex = value;
+                    OnChanged?.Invoke();
+                }
+            }
+        }
+
+        private bool _isCaseSensitive = false;
+        public bool isCaseSensitive
+        {
+            get => _isCaseSensitive;
+            set
+            {
+                if (_isCaseSensitive != value)
+                {
+                    _isCaseSensitive = value;
+                    OnChanged?.Invoke();
+                }
+            }
+        }
+
+        private string _expression = string.Empty;
+        public string expression
+        {
+            get => _expression;
+            set
+            {
+                if (_expression != value)
+                {
+                    _expression = value;
+                    regex = new Regex(_expression);
+                    OnChanged?.Invoke();
+                }
+            }
+        }
+
+        private FilterMode _filterMode = FilterMode.Inclusion;
+        public FilterMode filterMode
+        {
+            get => _filterMode;
+            set
+            {
+                if (_filterMode != value)
+                {
+                    _filterMode = value;
+                    OnChanged?.Invoke();
+                }
+            }
+        }
+
+        private FilterState _filterState = (FilterState)(-1);
+        public FilterState filterState
+        {
+            get => _filterState;
+            set
+            {
+                if (_filterState != value)
+                {
+                    _filterState = value;
+                    OnChanged?.Invoke();
+                }
+            }
+        }
+
+        private Regex regex = new Regex(string.Empty);
+
+        public bool IsPassingFilter(GameObjectMergeActions action)
+        {
+            if (!useFilter)
+            {
+                return true;
+            }
+
+            bool isPassingFilter = false;
+
+            string name = action.name;
+
+            if (isRegex)
+            {
+                isPassingFilter = regex.IsMatch(name);
             }
             else
             {
-                isPassingFilter = input.Contains(_expression);
+                if (!isCaseSensitive)
+                {
+                    name = name.ToLowerInvariant();
+                    isPassingFilter = name.Contains(_expression.ToLowerInvariant());
+                }
+                else
+                {
+                    isPassingFilter = name.Contains(_expression);
+                }
             }
-        }
 
-        if (filterMode == FilterMode.Exclusion)
-        {
-            isPassingFilter = !isPassingFilter;
-        }
+            if (filterMode == FilterMode.Exclusion)
+            {
+                isPassingFilter = !isPassingFilter;
+            }
 
-        return isPassingFilter;
+            bool isPassingFilterState = false;
+            if ((_filterState & FilterState.Conflict) != 0)
+            {
+                isPassingFilterState |= !action.merged;
+            }
+
+            if ((_filterState & FilterState.Done) != 0)
+            {
+                isPassingFilterState |= action.merged;
+            }
+            isPassingFilter &= isPassingFilterState;
+
+            return isPassingFilter;
+        }
     }
 }

--- a/Editor/MergeFilterBar.cs
+++ b/Editor/MergeFilterBar.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using GitMerge;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEditor.AnimatedValues;
@@ -17,13 +18,15 @@ public class MergeFilterBar
         {
             using (new EditorGUI.IndentLevelScope())
             {
-                filter.filterMode = (MergeFilter.FilterMode)EditorGUILayout.EnumPopup("Mode", filter.filterMode, GUILayout.ExpandWidth(false));
                 filter.isRegex = EditorGUILayout.Toggle("Regex?", filter.isRegex);
                 if (!filter.isRegex)
                 {
                     filter.isCaseSensitive = EditorGUILayout.Toggle("Case Sensitive", filter.isCaseSensitive);
                 }
                 filter.expression = EditorGUILayout.TextField("Expression", filter.expression, GUILayout.ExpandWidth(true));
+
+                filter.filterMode = (MergeFilter.FilterMode)EditorGUILayout.EnumPopup("Mode", filter.filterMode, GUILayout.Width(300), GUILayout.ExpandWidth(false));
+                filter.filterState = (MergeFilter.FilterState)EditorGUILayout.EnumFlagsField("Conflict State", filter.filterState, GUILayout.Width(300), GUILayout.ExpandWidth(false));
             }
         }
     }

--- a/Editor/Utilities/PageView.cs
+++ b/Editor/Utilities/PageView.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+public class PageView
+{
+    public int PageIndex { get; set; } = 0;
+    public int NumElementsPerPage { get; set; } = 10;
+
+    private Vector2 scrollPosition;
+
+    /// <summary>
+    /// Draw a scroll view only a limited number of elements displayed.
+    /// Add tool to change the page to display previous/next range of elements.
+    /// </summary>
+    /// <param name="numMaxElements">The total number of elements to draw.</param>
+    /// <param name="callbackElementDraw">Called for each element to draw. The element index to draw is passed as argument.</param>
+    public void Draw(int numMaxElements, Action<int> callbackElementDraw)
+    {
+        GUILayout.BeginVertical(GUILayout.ExpandWidth(true));
+        {
+            DrawPageContent(callbackElementDraw, numMaxElements);
+            DrawPageNavigation(numMaxElements);
+        }
+        GUILayout.EndVertical();
+    }
+
+    private void DrawPageContent(Action<int> callbackElementDraw, int numMaxElements)
+    {
+        scrollPosition = GUILayout.BeginScrollView(scrollPosition, false, true);
+        {
+            GUILayout.BeginVertical(GUILayout.ExpandWidth(true));
+
+            int lastElementIndex = Mathf.Min((PageIndex + 1) * NumElementsPerPage, numMaxElements);
+            for (int index = PageIndex * NumElementsPerPage; index < lastElementIndex; ++index)
+            {
+                callbackElementDraw(index);
+            }
+
+            GUILayout.EndVertical();
+        }
+        GUILayout.EndScrollView();
+    }
+
+    private void DrawPageNavigation(int numMaxElements)
+    {
+        int numPages = CalculateNumberOfPages(numMaxElements);
+
+        if (numPages == 0)
+        {
+            return;
+        }
+
+        GUILayout.BeginHorizontal();
+        {
+            EditorGUILayout.PrefixLabel("Count Per Page");
+            int newNumElementsPerPage = EditorGUILayout.DelayedIntField(NumElementsPerPage, GUILayout.Width(100));
+            if (newNumElementsPerPage != NumElementsPerPage)
+            {
+                NumElementsPerPage = Mathf.Max(newNumElementsPerPage, 1);
+                numPages = CalculateNumberOfPages(numMaxElements);
+            }
+
+            GUILayout.FlexibleSpace();
+
+            EditorGUI.BeginDisabledGroup(PageIndex == 0);
+            {
+                if (GUILayout.Button("<"))
+                {
+                    --PageIndex;
+                }
+            }
+            EditorGUI.EndDisabledGroup();
+
+            int newPageIndex = EditorGUILayout.DelayedIntField(PageIndex + 1, GUILayout.Width(30)) - 1;
+            PageIndex = Mathf.Clamp(newPageIndex, 0, numPages - 1);
+
+            GUILayout.Label("/" + numPages);
+
+            EditorGUI.BeginDisabledGroup(PageIndex == numPages - 1);
+            {
+                if (GUILayout.Button(">"))
+                {
+                    ++PageIndex;
+                }
+            }
+            EditorGUI.EndDisabledGroup();
+        }
+        GUILayout.EndHorizontal();
+    }
+
+    private int CalculateNumberOfPages(int numMaxElements)
+    {
+        int numPages = numMaxElements / NumElementsPerPage;
+        if (numMaxElements % NumElementsPerPage != 0)
+        {
+            ++numPages;
+        }
+
+        return numPages;
+    }
+}

--- a/Editor/Utilities/PageView.cs
+++ b/Editor/Utilities/PageView.cs
@@ -4,101 +4,104 @@ using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 
-public class PageView
+namespace GitMerge.Utilities
 {
-    public int PageIndex { get; set; } = 0;
-    public int NumElementsPerPage { get; set; } = 10;
-
-    private Vector2 scrollPosition;
-
-    /// <summary>
-    /// Draw a scroll view only a limited number of elements displayed.
-    /// Add tool to change the page to display previous/next range of elements.
-    /// </summary>
-    /// <param name="numMaxElements">The total number of elements to draw.</param>
-    /// <param name="callbackElementDraw">Called for each element to draw. The element index to draw is passed as argument.</param>
-    public void Draw(int numMaxElements, Action<int> callbackElementDraw)
+    public class PageView
     {
-        GUILayout.BeginVertical(GUILayout.ExpandWidth(true));
-        {
-            DrawPageContent(callbackElementDraw, numMaxElements);
-            DrawPageNavigation(numMaxElements);
-        }
-        GUILayout.EndVertical();
-    }
+        public int PageIndex { get; set; } = 0;
+        public int NumElementsPerPage { get; set; } = 10;
 
-    private void DrawPageContent(Action<int> callbackElementDraw, int numMaxElements)
-    {
-        scrollPosition = GUILayout.BeginScrollView(scrollPosition, false, true);
+        private Vector2 scrollPosition;
+
+        /// <summary>
+        /// Draw a scroll view only a limited number of elements displayed.
+        /// Add tool to change the page to display previous/next range of elements.
+        /// </summary>
+        /// <param name="numMaxElements">The total number of elements to draw.</param>
+        /// <param name="callbackElementDraw">Called for each element to draw. The element index to draw is passed as argument.</param>
+        public void Draw(int numMaxElements, Action<int> callbackElementDraw)
         {
             GUILayout.BeginVertical(GUILayout.ExpandWidth(true));
-
-            int lastElementIndex = Mathf.Min((PageIndex + 1) * NumElementsPerPage, numMaxElements);
-            for (int index = PageIndex * NumElementsPerPage; index < lastElementIndex; ++index)
             {
-                callbackElementDraw(index);
+                DrawPageContent(callbackElementDraw, numMaxElements);
+                DrawPageNavigation(numMaxElements);
             }
-
             GUILayout.EndVertical();
         }
-        GUILayout.EndScrollView();
-    }
 
-    private void DrawPageNavigation(int numMaxElements)
-    {
-        int numPages = CalculateNumberOfPages(numMaxElements);
-
-        if (numPages == 0)
+        private void DrawPageContent(Action<int> callbackElementDraw, int numMaxElements)
         {
-            return;
-        }
-
-        GUILayout.BeginHorizontal();
-        {
-            EditorGUILayout.PrefixLabel("Count Per Page");
-            int newNumElementsPerPage = EditorGUILayout.DelayedIntField(NumElementsPerPage, GUILayout.Width(100));
-            if (newNumElementsPerPage != NumElementsPerPage)
+            scrollPosition = GUILayout.BeginScrollView(scrollPosition, false, true);
             {
-                NumElementsPerPage = Mathf.Max(newNumElementsPerPage, 1);
-                numPages = CalculateNumberOfPages(numMaxElements);
-            }
+                GUILayout.BeginVertical(GUILayout.ExpandWidth(true));
 
-            GUILayout.FlexibleSpace();
-
-            EditorGUI.BeginDisabledGroup(PageIndex == 0);
-            {
-                if (GUILayout.Button("<"))
+                int lastElementIndex = Mathf.Min((PageIndex + 1) * NumElementsPerPage, numMaxElements);
+                for (int index = PageIndex * NumElementsPerPage; index < lastElementIndex; ++index)
                 {
-                    --PageIndex;
+                    callbackElementDraw(index);
                 }
+
+                GUILayout.EndVertical();
             }
-            EditorGUI.EndDisabledGroup();
-
-            int newPageIndex = EditorGUILayout.DelayedIntField(PageIndex + 1, GUILayout.Width(30)) - 1;
-            PageIndex = Mathf.Clamp(newPageIndex, 0, numPages - 1);
-
-            GUILayout.Label("/" + numPages);
-
-            EditorGUI.BeginDisabledGroup(PageIndex == numPages - 1);
-            {
-                if (GUILayout.Button(">"))
-                {
-                    ++PageIndex;
-                }
-            }
-            EditorGUI.EndDisabledGroup();
+            GUILayout.EndScrollView();
         }
-        GUILayout.EndHorizontal();
-    }
 
-    private int CalculateNumberOfPages(int numMaxElements)
-    {
-        int numPages = numMaxElements / NumElementsPerPage;
-        if (numMaxElements % NumElementsPerPage != 0)
+        private void DrawPageNavigation(int numMaxElements)
         {
-            ++numPages;
+            int numPages = CalculateNumberOfPages(numMaxElements);
+
+            if (numPages == 0)
+            {
+                return;
+            }
+
+            GUILayout.BeginHorizontal();
+            {
+                EditorGUILayout.PrefixLabel("Count Per Page");
+                int newNumElementsPerPage = EditorGUILayout.DelayedIntField(NumElementsPerPage, GUILayout.Width(100));
+                if (newNumElementsPerPage != NumElementsPerPage)
+                {
+                    NumElementsPerPage = Mathf.Max(newNumElementsPerPage, 1);
+                    numPages = CalculateNumberOfPages(numMaxElements);
+                }
+
+                GUILayout.FlexibleSpace();
+
+                EditorGUI.BeginDisabledGroup(PageIndex == 0);
+                {
+                    if (GUILayout.Button("<"))
+                    {
+                        --PageIndex;
+                    }
+                }
+                EditorGUI.EndDisabledGroup();
+
+                int newPageIndex = EditorGUILayout.DelayedIntField(PageIndex + 1, GUILayout.Width(30)) - 1;
+                PageIndex = Mathf.Clamp(newPageIndex, 0, numPages - 1);
+
+                GUILayout.Label("/" + numPages);
+
+                EditorGUI.BeginDisabledGroup(PageIndex == numPages - 1);
+                {
+                    if (GUILayout.Button(">"))
+                    {
+                        ++PageIndex;
+                    }
+                }
+                EditorGUI.EndDisabledGroup();
+            }
+            GUILayout.EndHorizontal();
         }
 
-        return numPages;
+        private int CalculateNumberOfPages(int numMaxElements)
+        {
+            int numPages = numMaxElements / NumElementsPerPage;
+            if (numMaxElements % NumElementsPerPage != 0)
+            {
+                ++numPages;
+            }
+
+            return numPages;
+        }
     }
 }

--- a/Editor/Utilities/PageView.cs.meta
+++ b/Editor/Utilities/PageView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e670dcb0849e9cc4292d2d2e86aee42c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
I've got a case where there were so much conflicts (9343) that my editor froze, so I set a kind of "page" system to display only a limited number of conflict. Well, in any case, it is too much for me to fix theses conflicts manually but at least, it doesn't explode haha.
The visual is not really amazing but I suppose it is ok.
Also, the system can be reused easily if necessary.

Also, it is important to note that filtered mergeActions are now cached. Otherwise, it would have been heavy to get a list of elements filtered, count the number of elements (required to determine the number of pages to display) and then make the view drawing for each frame.