### PR TITLE
Support for RectTransform Live Preview & proper Focus on Prefabs

### DIFF
--- a/Editor/GameObjectMergeActions.cs
+++ b/Editor/GameObjectMergeActions.cs
@@ -328,7 +328,7 @@ namespace GitMerge
             {
                 // Highlight the instance of the prefab, not the prefab itself.
                 // Otherwise, "ours".
-                var objectToHighlight = MergeManagerBase.isMergingPrefab ? MergeManagerPrefab.ourPrefabInstance : ours;
+                var objectToHighlight = MergeManagerBase.isMergingPrefab ? MergeManagerPrefab.ourPrefabInstance.GetChildWithEqualPath(ours) : ours;
                 objectToHighlight.Highlight();
             }
             GUILayout.EndHorizontal();

--- a/Editor/GameObjectMergeActions.cs
+++ b/Editor/GameObjectMergeActions.cs
@@ -69,7 +69,7 @@ namespace GitMerge
             name = "";
             if (ours)
             {
-                name = "Your[" + GetPath(ours) + "]";
+                name = "Your[" + ours.GetPath() + "]";
             }
             if (theirs)
             {
@@ -77,7 +77,7 @@ namespace GitMerge
                 {
                     name += " vs. ";
                 }
-                name += "Their[" + GetPath(theirs) + "]";
+                name += "Their[" + theirs.GetPath() + "]";
             }
         }
 
@@ -249,31 +249,6 @@ namespace GitMerge
             }
 
             return !object.Equals(our, their);
-        }
-
-        /// <summary>
-        /// Get the path of a GameObject in the hierarchy.
-        /// </summary>
-        private static string GetPath(GameObject gameObject)
-        {
-            var t = gameObject.transform;
-            var sb = new StringBuilder(RemovePostfix(t.name));
-            while (t.parent != null)
-            {
-                t = t.parent;
-                sb.Insert(0, RemovePostfix(t.name) + "/");
-            }
-            return sb.ToString();
-        }
-
-        private static string RemovePostfix(string name)
-        {
-            if (name.EndsWith(MergeManagerBase.THEIR_FILE_POSTFIX))
-            {
-                return name.Substring(0, name.Length - MergeManagerBase.THEIR_FILE_POSTFIX.Length);
-            }
-
-            return name;
         }
 
         private void CheckIfMerged()

--- a/Editor/MergeActions/MergeAction.cs
+++ b/Editor/MergeActions/MergeAction.cs
@@ -154,8 +154,7 @@ namespace GitMerge
         {
             // Highlight the instance of the prefab, not the prefab itself
             // Otherwise, "ours".
-            var objectToHighlight = MergeManagerBase.isMergingPrefab ? MergeManagerPrefab.ourPrefabInstance : ours;
-
+            var objectToHighlight = MergeManagerBase.isMergingPrefab ? MergeManagerPrefab.ourPrefabInstance.GetChildWithEqualPath(ours) : ours;
             if (objectToHighlight && inMergePhase && objectToHighlight.hideFlags == HideFlags.None)
             {
                 objectToHighlight.Highlight();

--- a/Editor/MergeManagerPrefab.cs
+++ b/Editor/MergeManagerPrefab.cs
@@ -52,6 +52,13 @@ namespace GitMerge
             // Instantiate our object in order to view it while merging.
             ourPrefabInstance = PrefabUtility.InstantiatePrefab(ourPrefab) as GameObject;
             
+            // UI Elements need a Canvas to be displayed correctly:
+            if (ourPrefabInstance.GetComponentInChildren<RectTransform>() != null) {
+                GameObject defaultCanvas = new GameObject("Canvas");
+                defaultCanvas.AddComponent<Canvas>().renderMode = RenderMode.ScreenSpaceOverlay;
+                ourPrefabInstance.transform.SetParent(defaultCanvas.transform, false);
+            }
+
             var ourObjects = GetAllObjects(ourPrefab);
 
             theirPrefab = AssetDatabase.LoadAssetAtPath(theirFilename, typeof(GameObject)) as GameObject;

--- a/Editor/Utilities/GameObjectExtensions.cs
+++ b/Editor/Utilities/GameObjectExtensions.cs
@@ -1,6 +1,7 @@
 ﻿
 namespace GitMerge
 {
+    using System.Text;
     using UnityEngine;
     using UnityEditor;
 
@@ -54,6 +55,11 @@ namespace GitMerge
         /// <param name="go">The GameObject of interest</param>
         public static void Highlight(this GameObject go)
         {
+            // Focussing on the same object twice, zooms in to the coordinate instead of the bounding box.
+            if (Selection.activeObject == go) {
+                return;
+            }
+
             Selection.activeGameObject = go;
             EditorGUIUtility.PingObject(go);
 
@@ -62,6 +68,43 @@ namespace GitMerge
             {
                 view.FrameSelected();
             }
+        }
+        
+        /// <summary>
+        /// Gets the path of this GameObject in the hierarchy.
+        /// </summary>
+        public static string GetPath(this GameObject gameObject)
+        {
+            var t = gameObject.transform;
+            var sb = new StringBuilder(RemovePostfix(t.name));
+            while (t.parent != null)
+            {
+                t = t.parent;
+                sb.Insert(0, RemovePostfix(t.name) + "/");
+            }
+            return sb.ToString();
+        }
+        
+        /// <summary>
+        /// Returns a child of this GameObject that has the same relative path to this GamObject as
+        /// the given GameObject has to it's root GameObject. 
+        /// </summary>
+        public static GameObject GetChildWithEqualPath(this GameObject gameObject, GameObject otherGameObject)
+        {
+            string fullHierarchyPath = otherGameObject.GetPath();
+            string relativeHierarchyPath = fullHierarchyPath.Substring(fullHierarchyPath.IndexOf("/", 1) + 1);
+            Transform result = gameObject.transform.Find(relativeHierarchyPath);
+            return result != null ? result.gameObject : gameObject; // fallback to root if a GameObject with equal path doesn't exist
+        }
+        
+        private static string RemovePostfix(string name)
+        {
+            if (name.EndsWith(MergeManagerBase.THEIR_FILE_POSTFIX))
+            {
+                return name.Substring(0, name.Length - MergeManagerBase.THEIR_FILE_POSTFIX.Length);
+            }
+
+            return name;
         }
     }
 }


### PR DESCRIPTION
See Issue: https://github.com/FlaShG/GitMerge-for-Unity/issues/67

Live Preview Support fort rect transforms was added by automatically adding a screen space canvas to the scene and making it the parent of the prefab instance, if the prefab contains one or more RectTransforms (assuming it's a UI element then). This matches the behaviour of Unitys Prefab Editor.

For proper focus support on Prefabs, the original code always passed a long the prefab root instead a reference to the GameObject that should be focused on. So my changes use the `ours` GameObject reference to read which GameObject should actually be highlighted and then it uses `Transform.Find` to find the matching GameObject within the instantiated Prefab.
